### PR TITLE
Fixed font errors with Roboto

### DIFF
--- a/styles/global.js
+++ b/styles/global.js
@@ -194,7 +194,7 @@ export const globalStyles = StyleSheet.create({
    * About page fonts
    **************************/
   aboutTitle: {
-    fontFamily: 'Roboto, nunito-bold',
+    fontFamily: 'nunito-bold',
     fontSize: 23,
     fontWeight: 'bold',
     color: '#000',


### PR DESCRIPTION
Deleted 'Roboto' and replaced with 'nunito-bold' to fix error on About page